### PR TITLE
fix(docs): correct PUBLIC_URL type

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ To run Erin, you will need to set the following environment variables in a `.env
 
 | Parameter               | Type      | Description                | Default |
 | :---------------------- | :-------- | :------------------------- | ------- |
-| `PUBLIC_URL`            | `boolean` | The public URL used to remotely access your instance of Erin. (Please include HTTP / HTTPS and the port if not standard 80 or 443. Do not include a trailing slash) (Read the [official Caddy documentation](https://caddyserver.com/docs/caddyfile/concepts#addresses)) | https://localhost        
+| `PUBLIC_URL`            | `string`  | The public URL used to remotely access your instance of Erin. (Please include HTTP / HTTPS and the port if not standard 80 or 443. Do not include a trailing slash) (Read the [official Caddy documentation](https://caddyserver.com/docs/caddyfile/concepts#addresses)) | https://localhost |
 | `AUTH_ENABLED`          | `string`  | Whether Basic Authentication should be enabled. (This parameter is case sensitive) (Possible values : true, false) | true |
 | `AUTH_SECRET`           | `string`  | The secure hash of the password used to protect your instance of Erin. | Hash of `secure-password` |
 | `APP_TITLE`             | `string`  | The custom title that you would like to display in the browser's tab. (Tip: You can use `[VIDEO_TITLE]` here if you want Erin to dynamically display the title of the current video.) | Erin - TikTok feed for your own clips |


### PR DESCRIPTION
## Summary
- correct PUBLIC_URL from boolean to string in the README configuration table
- trim trailing whitespace on the touched table row

## Validation
- git diff --check

Closes #39